### PR TITLE
Fix CityStates scroll panel sizing

### DIFF
--- a/CIVITAS City-States/Core/Utilities/UI Replacements/CityStates.lua
+++ b/CIVITAS City-States/Core/Utilities/UI Replacements/CityStates.lua
@@ -1278,8 +1278,14 @@ function ViewList()
 		Controls.BonusScroll:CalculateSize();
 		--Controls.BonusArea:ReprocessAnchoring();
 
+        -- Kopachris: adjust relative sizing of the two scroll areas
+        -- adjust m_bonusAreaRatio to change how much space it gets
+        -- m_bonusAreaRatio = 0.5 is about half and half
+        local m_bonusAreaRatio = 0.5;
+        Controls.BonusArea:SetSizeY( (m_height - 264) * m_bonusAreaRatio );
 		local bonusAreaY:number = Controls.BonusArea:GetSizeY();
-		Controls.CityStateScroll:SetSizeY( m_height - (264 + bonusAreaY ) );
+		Controls.BonusScroll:CalculateSize();
+		Controls.CityStateScroll:SetSizeY( m_height - 264 - bonusAreaY );
 
 	else
 		Controls.BonusArea:SetHide( true );

--- a/CIVITAS City-States/Core/Utilities/UI Replacements/CityStates.xml
+++ b/CIVITAS City-States/Core/Utilities/UI Replacements/CityStates.xml
@@ -42,14 +42,16 @@
                 </Grid>
             </Grid>
 
-            <ScrollPanel ID="CityStateScroll" Offset="12,164" Size="490,parent-174" Vertical="1" AutoScrollBar="1">
+            <!--Kopachris: originally Size="490,parent-174"-->
+            <ScrollPanel ID="CityStateScroll" Offset="12,164" Size="490,500" Vertical="1" AutoScrollBar="1">
                 <Stack ID="CityStateStack" Anchor="L,T" Offset="0,1" StackPadding="4" />
                 <ScrollBar Anchor="R,C" Offset="-1,0" AnchorSide="O,I" Style="ScrollVerticalBarAlt" />
             </ScrollPanel>
 
             <Label ID="NoneMet" Anchor="C,C" Offset="0,50" Align="Center" Style="FontFlair20" String="LOC_CITY_STATES_NONE_MET" Hidden="1"/>
 
-            <Grid ID="BonusArea" Anchor="L,B" Offset="0,70" Size="parent,parent-570" Texture="Controls_Glow" SliceCorner="90,90" SliceTextureSize="179,178" Color="0,0,0,255" Hidden="1">
+            <!--Kopachris: originally Size="parent,parent-570"-->
+            <Grid ID="BonusArea" Anchor="L,B" Offset="0,70" Size="parent,600" Texture="Controls_Glow" SliceCorner="90,90" SliceTextureSize="179,178" Color="0,0,0,255" Hidden="1">
                 <Grid ID="BonusDecoLeft" Offset="20,45" Size="18,parent-50" Texture="Controls_Deco" SliceCorner="9,24" SliceTextureSize="18,49" Color="30,36,40,255" />
                 <Grid ID="BonusDecoRight" Anchor="R,T" Offset="20,45" Size="18,parent-50" Texture="Controls_Deco" SliceCorner="9,24" SliceTextureSize="18,49" Color="30,36,40,255" SliceStart="20,0" />
 
@@ -57,7 +59,8 @@
                     <Image Size="parent,parent" Texture="Controls_Gradient_HalfRadial" Color="170,176,180,35" />
                     <Label ID="SubHeader" Anchor="C,C" Offset="0,3" Style="FontFlair24" Color0="170,176,180" String="{LOC_CITY_STATES_BONUSES_EARNED:upper}" SmallCaps="30" SmallCapsType="EveryWord" />
                 </Grid>
-                <ScrollPanel ID="BonusScroll" Offset="50,39" Size="400,parent-39" Vertical="1">
+                <!--Kopachris: added AutoScrollBar="1"-->
+                <ScrollPanel ID="BonusScroll" Offset="50,39" Size="400,parent-39" Vertical="1" AutoScrollBar="1">
                     <Stack ID="BonusStack" Anchor="L,T" Offset="0,1" StackPadding="4" />
                     <ScrollBar Anchor="R,C" Offset="10,0" AnchorSide="O,I" Style="ScrollVerticalBarAlt" />
                 </ScrollPanel>


### PR DESCRIPTION
Original had the BonusArea fixed to a large portion of the vertical screen real estate (parent-570px), leaving not much for the actual list of city states. This commit makes them proportional to actual render resolution, with both panels each taking about half the space at any screen resolution. The problem was especially noticeable with high screen resolutions (2K and above) at 100% scaling, and with more than a handful of city states discovered. 

Before, see how the CityStateScroll area is all scrunched up? https://i.imgur.com/IovCeZs.png 

Muuuuch better: https://i.imgur.com/xJTR6V0.png